### PR TITLE
refactor: remove config loading from environment vars

### DIFF
--- a/config/settings/firebase_settings.py
+++ b/config/settings/firebase_settings.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
+
 
 class FirebaseSettings(BaseSettings):
     enabled: bool = False

--- a/config/settings/firebase_settings.py
+++ b/config/settings/firebase_settings.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseSettings
 
-
-class FirebaseSettings(BaseModel):
+class FirebaseSettings(BaseSettings):
     enabled: bool = False
+
+    class Config:
+        env_prefix = "FIREBASE_"

--- a/config/slack_config.py
+++ b/config/slack_config.py
@@ -48,19 +48,6 @@ class SlackAppConfig(AppConfig):
         )
         logging.info("Configuration loaded from file %s", config_file)
 
-    def load_config_from_env_vars(self) -> None:
-        """
-        Load configuration from environment variables.
-
-        This method loads the Firebase and API related settings from the
-        environment variables. It validates the configurations based on the
-        enabled/disabled status of certain features.
-        """
-        # Load Firebase settings
-        self.firebase_settings.enabled = load_env_value(
-            "FIREBASE_ENABLED", self.firebase_settings.enabled, bool
-        )
-
     def _validate_config(self) -> None:
         """Validate that required configuration variables are present."""
         super()._validate_config()
@@ -169,6 +156,6 @@ class SlackAppConfig(AppConfig):
             self.load_config_from_file("config.ini")
         else:
             # If no config file provided, load config from environment variables
-            self.load_config_from_env_vars()
+            pass
 
         self._validate_config()

--- a/config/slack_config.py
+++ b/config/slack_config.py
@@ -6,7 +6,6 @@ import os
 from google.cloud import firestore
 
 from config.app_config import AppConfig
-from config.loaders.env_loader import load_env_value
 from config.loaders.firebase_loader import load_settings_from_firestore
 from config.loaders.ini_loader import load_settings_from_ini_section
 from config.settings.api_settings import APISettings

--- a/tests/test_slack_config.py
+++ b/tests/test_slack_config.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import os
 import unittest
-from unittest.mock import patch
 
 from config.settings.api_settings import APISettings
 from config.settings.firebase_settings import FirebaseSettings

--- a/tests/test_slack_config.py
+++ b/tests/test_slack_config.py
@@ -33,22 +33,6 @@ class TestSlackAppConfig(unittest.TestCase):
         }
         self.app_config = SlackAppConfig()
 
-    def test_load_config_from_env_vars(self) -> None:
-        """Test load_config_from_env_vars() to verify correct reading of environment variables."""
-        with patch.dict(
-            os.environ,
-            {
-                "OPENAI_API_KEY": "test",
-                "SLACK_BOT_TOKEN": "test",
-                "SLACK_APP_TOKEN": "test",
-                "CHAT_MODEL": "gpt-4",
-                "SYSTEM_PROMPT": "You are a helpful assistant.",
-                "TEMPERATURE": "0",
-                "FIREBASE_ENABLED": "False",
-            },
-        ):
-            self.app_config.load_config_from_env_vars()
-
     def test_validation(self):
         """Test configuration validation logic."""
         self.app_config.api_settings = APISettings(


### PR DESCRIPTION
…ings class

Remove methods for loading configuration from environment variables in `SlackAppConfig`. Update `FirebaseSettings` class to inherit from `BaseSettings` and add `Config` class with `env_prefix`. Adjust related tests accordingly.